### PR TITLE
Fix build errors and add qt5 support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
+cmake_minimum_required(VERSION 3.5)
 
 project(GraphCutSegment)
-cmake_minimum_required(VERSION 2.8.9)
 
 #-----------------------------------------------------------------------------
 # Extension meta-information

--- a/GraphCutInteractiveSegmenter/CMakeLists.txt
+++ b/GraphCutInteractiveSegmenter/CMakeLists.txt
@@ -17,7 +17,6 @@ endif()
 #-----------------------------------------------------------------------------
 add_subdirectory(Logic)
 add_subdirectory(Widgets)
-#add_subdirectory(MRMLDM)
 
 #-----------------------------------------------------------------------------
 set(MODULE_EXPORT_DIRECTIVE "Q_SLICER_QTMODULES_${MODULE_NAME_UPPER}_EXPORT")
@@ -64,24 +63,6 @@ set(MODULE_TARGET_LIBRARIES
 set(MODULE_RESOURCES
   Resources/qSlicer${MODULE_NAME}Module.qrc
   )
-
-#----------------------------------------------------------------------------
-#include(${VTK_CMAKE_DIR}/vtkMakeInstantiator.cmake)
-#set(displayable_manager_SRCS
-#  vtkMRMLGraphCutInteractiveSegmenterDisplayableManager.cxx
-# )
-#set(VTK_USE_INSTANTIATOR_NEW 1)
-#VTK_MAKE_INSTANTIATOR3("${MODULE_NAME}Instantiator"
-#  displayable_manager_instantiator_SRCS
-#  "${displayable_manager_SRCS}"
-#  "${${KIT}_EXPORT_DIRECTIVE}"
-#  ${CMAKE_CURRENT_BINARY_DIR}
-#  "${KIT}Export.h"
-#  )
-#set(${KIT}_SRCS
-#  ${displayable_manager_instantiator_SRCS}
-#  ${displayable_manager_SRCS}
-#  )
 
 #-----------------------------------------------------------------------------
 slicerMacroBuildQtModule(

--- a/GraphCutInteractiveSegmenter/CMakeLists.txt
+++ b/GraphCutInteractiveSegmenter/CMakeLists.txt
@@ -1,8 +1,7 @@
-#cmake_minimum_required(VERSION 2.8.9)
-
-#find_package(Slicer COMPONENTS ConfigurePrerequisites)
+cmake_minimum_required(VERSION 3.5)
 
 project(GraphCutInteractiveSegmenter)
+
 #-----------------------------------------------------------------------------
 set(MODULE_NAME GraphCutInteractiveSegmenter)
 set(MODULE_TITLE ${MODULE_NAME})

--- a/GraphCutInteractiveSegmenter/Logic/TumorSegm/AppData.h
+++ b/GraphCutInteractiveSegmenter/Logic/TumorSegm/AppData.h
@@ -24,6 +24,7 @@ class AppData
 {
 public:
     AppData();
+
     void loadImage(vtkImageData* image,MyBasic::Range3D imgBox);
 	vtkSmartPointer<vtkImageData> getLabelMap();
 
@@ -33,12 +34,12 @@ public:
     //mask with user seeds
     Data3D<LABEL> mask;
     MyBasic::Range3D tightBox;
-	MyBasic::Range3D shifttightBox;
+    MyBasic::Range3D shifttightBox;
     MyBasic::Index3D imgStart;
-	MyBasic::Index3D wholeRange;
-	MyBasic::Index3D star_first;
+    MyBasic::Index3D wholeRange;
+    MyBasic::Index3D star_first;
     MyBasic::Index3D star_last;
-	MyBasic::Index3D shiftstar_first;
+    MyBasic::Index3D shiftstar_first;
     MyBasic::Index3D shiftstar_last;
     Config cfg;
 

--- a/GraphCutInteractiveSegmenter/Logic/TumorSegm/CMakeLists.txt
+++ b/GraphCutInteractiveSegmenter/Logic/TumorSegm/CMakeLists.txt
@@ -1,11 +1,9 @@
 cmake_minimum_required(VERSION 3.5)
 
 project(TumorSegm)
-set(tumor_segm_name "${PROJECT_NAME}")
 
-FIND_PACKAGE(VTK)
-INCLUDE(${VTK_USE_FILE})
-INCLUDE("${VTK_DIR}/Common/DataModel/CMakeFiles/vtkCommonDataModel.cmake")
+find_package(VTK)
+include(${VTK_USE_FILE})
 
 set(tumor_segm_SRCS
   AdaptiveSegment2D.cpp
@@ -45,8 +43,5 @@ set(tumor_segm_SRCS
   )
 
 add_library(TumorSegm STATIC ${tumor_segm_SRCS})
-
-
-TARGET_LINK_LIBRARIES(vtkCommonDataModel)
-
+target_link_libraries(TumorSegm PUBLIC ${VTK_LIBRARIES})
 

--- a/GraphCutInteractiveSegmenter/Logic/TumorSegm/CMakeLists.txt
+++ b/GraphCutInteractiveSegmenter/Logic/TumorSegm/CMakeLists.txt
@@ -5,6 +5,8 @@ project(TumorSegm)
 find_package(VTK)
 include(${VTK_USE_FILE})
 
+set(CMAKE_POSITION_INDEPENDENT_CODE 1)
+
 set(tumor_segm_SRCS
   AdaptiveSegment2D.cpp
   AdaptiveSegment2D.h

--- a/GraphCutInteractiveSegmenter/Logic/TumorSegm/CMakeLists.txt
+++ b/GraphCutInteractiveSegmenter/Logic/TumorSegm/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8)
+cmake_minimum_required(VERSION 3.5)
 
 project(TumorSegm)
 set(tumor_segm_name "${PROJECT_NAME}")

--- a/GraphCutInteractiveSegmenter/Logic/vtkSlicerGraphCutInteractiveSegmenterLogic.cxx
+++ b/GraphCutInteractiveSegmenter/Logic/vtkSlicerGraphCutInteractiveSegmenterLogic.cxx
@@ -100,7 +100,8 @@ bool isPainter;
 //----------------------------------------------------------------------------
 vtkSlicerGraphCutInteractiveSegmenterLogic::vtkSlicerGraphCutInteractiveSegmenterLogic()
 {
-	this->gData = AppData::AppData();
+	AppData data;
+	this->gData = data;
 	this->seg = NULL;
 	this->ROI=NULL;
 	this->cropROI=NULL;
@@ -982,6 +983,7 @@ void vtkSlicerGraphCutInteractiveSegmenterLogic::reset(vtkMRMLMarkupsFiducialNod
 		this->GetMRMLScene()->RemoveNode(this->ROI);
 	}
 	this->seg=NULL;
-	this->gData = AppData::AppData();
+	AppData data;
+	this->gData = data;
 	this->totalTime=0;
 }

--- a/GraphCutInteractiveSegmenter/Widgets/CMakeLists.txt
+++ b/GraphCutInteractiveSegmenter/Widgets/CMakeLists.txt
@@ -21,7 +21,7 @@ set(${KIT}_UI_SRCS
   )
 
 set(${KIT}_RESOURCES
-  ../Resources/UI/qSlicer${MODULE_NAME}FooBarWidget.ui
+  ../Resources/qSlicer${MODULE_NAME}Module.qrc
   )
 
 set(${KIT}_TARGET_LIBRARIES

--- a/GraphCutInteractiveSegmenter/qSlicerGraphCutInteractiveSegmenterModule.cxx
+++ b/GraphCutInteractiveSegmenter/qSlicerGraphCutInteractiveSegmenterModule.cxx
@@ -38,7 +38,10 @@
 //#include "vtkMRMLThreeDViewDisplayableManagerFactory.h"
 
 //-----------------------------------------------------------------------------
+#if (QT_VERSION < QT_VERSION_CHECK(5, 0, 0))
+#include <QtPlugin>
 Q_EXPORT_PLUGIN2(qSlicerGraphCutInteractiveSegmenterModule, qSlicerGraphCutInteractiveSegmenterModule);
+#endif
 
 //-----------------------------------------------------------------------------
 /// \ingroup Slicer_QtModules_ExtensionTemplate

--- a/GraphCutInteractiveSegmenter/qSlicerGraphCutInteractiveSegmenterModule.h
+++ b/GraphCutInteractiveSegmenter/qSlicerGraphCutInteractiveSegmenterModule.h
@@ -31,6 +31,9 @@ qSlicerGraphCutInteractiveSegmenterModule
   : public qSlicerLoadableModule
 {
   Q_OBJECT
+#ifdef Slicer_HAVE_QT5
+  Q_PLUGIN_METADATA(IID "org.slicer.modules.loadable.qSlicerLoadableModule/1.0");
+#endif
   Q_INTERFACES(qSlicerLoadableModule);
 
 public:


### PR DESCRIPTION
@DaphneCD While testing the recent updates associated with Slicer build system, I ended updating your extension

Please, consider reviewing and testing this set of changes.

As a side note:
* I noticed that the library [TumorSegm](https://github.com/DaphneCD/GraphCutSegmentExtension/tree/master/GraphCutInteractiveSegmenter/Logic/TumorSegm) is not clear. It is mentioned that *This project can be used for research purposes only.*. Do you know what this means exactly ? 
* There is still a lot of warnings associated with `TumorSegm` library, would be great to address them.

Let us know with you have any questions. The  [Slicer discussion forum](https://discourse.slicer.org) is a good outlet for questions.

As a side note, the migration guide associated with VTK6, VTK7, VTK8, Qt5 and Slicer are now all linked of https://www.slicer.org/wiki/Documentation/Nightly/Developers/Tutorials/MigrationGuide

Cc: @fedorov @lassoan @pieper